### PR TITLE
Consistent build path & clearer build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ osx run:
 ## build/run
 
 1. Clone repository
-1. `mkdir ${repo_root}/build`
+1. cd <new repo dir>
+1. `mkdir build`
 1. `cd build`
-1. `cmake ..`
+1. `cmake ../`
 1. `make`
 1. `./src/entity-generator/entity-generator`


### PR DESCRIPTION
Richard asked about building this tool, and there was some confusion on the build dir & where it existed.  These steps are hopefully a little more clear.

Also, added a `/` at the end of the cmake line to make it harder to miss the dots that point to the parent dir