### PR TITLE
Test patterns and samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 build/
 .*sw*
+venv

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,9 @@
+#Entity generator helper scripts
+
+These helper scripts are intended to make visualizing a "live" test pattern easy.
+
+##Steps:
+
+1. Run `setup.sh` to install the python virtual environment and dependencies
+1. Run `./generate-test-pattern <host> <api-key>`.  This will create a dataset, lens template and start ingesting.
+1. Optional:  When finished run `cleanup-test-patterns` to delete all resources with "generated-test-pattern" in their names (may be DANGEROUS).

--- a/scripts/cleanup-test-patterns
+++ b/scripts/cleanup-test-patterns
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "Are you sure!"
+echo -n "This will delete all resource with "generated-test-pattern" in the name (Yes/n): "
+read answer
+
+if [ "${answer}" == "Yes" ] ; then
+    ./venv/bin/conduce-api remove --regex=generated-test-pattern --all 
+else
+   echo "Operation aborted"
+fi

--- a/scripts/dots_template.json
+++ b/scripts/dots_template.json
@@ -1,0 +1,62 @@
+{
+  "kinds": [
+    "generated-test-dot"
+  ],
+  "name": "",
+  "renderings": [{
+    "use_high_precision_time": true,
+    "name": "dots",
+    "rule": {
+      "kinds": [
+        "generated-test-dot"
+      ],
+      "match": "ALL"
+    },
+    "point": [{
+      "uniforms": [{
+          "type": "GL_FLOAT",
+          "shader_uniform": "size_base",
+          "float_value": [
+            0.1
+          ]
+        },
+        {
+          "type": "GL_FLOAT",
+          "shader_uniform": "reference_zoom",
+          "float_value": [
+            2
+          ]
+        },
+        {
+          "type": "GL_VEC4",
+          "shader_uniform": "color_base",
+          "vec_value": [{
+            "y": 0.63072,
+            "x": 0.0192,
+            "z": 0.96,
+            "w": 0.45490196
+          }]
+        }
+      ],
+      "shader": {
+        "fragment": {
+          "uri": "dots/fragment.glsl"
+        },
+        "vertex": {
+          "uri": "dots/vertex.glsl"
+        }
+      },
+      "defines": [{
+        "shader_define_name": "SCALE_LOG"
+      }]
+    }]
+  }],
+  "renderer_service_name": "marker",
+  "dataset_id": "",
+  "hover_info": [{
+    "hoverable": true,
+    "kinds": [
+      "generated-test-dot"
+    ]
+  }]
+}

--- a/scripts/generate-test-pattern
+++ b/scripts/generate-test-pattern
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./venv/bin/python generate_test_pattern.py $@

--- a/scripts/generate_test_pattern.py
+++ b/scripts/generate_test_pattern.py
@@ -1,0 +1,100 @@
+import conduce.api
+import subprocess
+import os
+import sys
+import json
+
+
+def initialize_test(kind, args):
+    resource_info = conduce.api.create_dataset(
+        'generated-test-pattern', host=args.host, api_key=args.api_key)
+    dataset_id = resource_info['id']
+
+    lens_template_name = 'generated-test-pattern-dots'
+    lens_template = json.load(open('dots_template.json'))
+
+    lens_template['name'] = lens_template_name
+    lens_template['dataset_id'] = dataset_id
+
+    # TODO: Some fancy iteration over the template to catch all occurrences of "kinds"
+    lens_template['kinds'] = [kind]
+    lens_template['renderings'][0]['rule']['kinds'] = [kind]
+    lens_template['hover_info'][0]['kinds'] = [kind]
+
+    conduce.api.create_template(
+        lens_template_name, lens_template, host=args.host, api_key=args.api_key)
+
+    return dataset_id
+
+
+def get_dataset_id(args):
+    dataset_id = None
+
+    dataset_list = conduce.api.find_dataset(
+        name=args.dataset_name, host=args.host, api_key=args.api_key)
+
+    if len(dataset_list) == 1:
+        dataset_id = datatset_list[0]['id']
+    else:
+        print 'More than one dataset found with name {}'.format(dataset_name)
+        print dataset_list
+
+    return dataset_id
+
+
+def check_dataset_id(args):
+    resource_list = conduce.api.find_dataset(
+        id=args.dataset_id, host=args.host, api_key=args.api_key)
+    return len(resource_list) == 1
+
+
+def main():
+    import argparse
+
+    arg_parser = argparse.ArgumentParser(
+        description='Generate and ingest an entity test pattern.  This tool can be used to generate a live stream or flood the ingest interface with data.  By default, a new dataset is created along with a lens template for viewing the data.  Then it generates and ingests test pattern data.  If the user provides a dataset ID or dataset name the dataset and lens template are not created.')
+    arg_parser.add_argument(
+        'host', help='The server on which the command will run')
+    arg_parser.add_argument(
+        'api_key', help='The API key used to authenticate')
+    arg_parser.add_argument(
+        '--dataset-id', help='The ID of the dataset to ingest data to, overrides dataset-name')
+    arg_parser.add_argument(
+        '--dataset-name', help='The name of the dataset to ingest data to, fails if more than one dataset found')
+
+    args = arg_parser.parse_args()
+
+    entity_count = 64
+    kind = 'generated-test-dot'
+
+    if args.dataset_id is not None:
+        if check_dataset_id(args):
+            dataset_id = args.dataset_id
+        else:
+            print '{} is an invalid dataset ID'.format(args.dataset_id)
+            sys.exit(2)
+    elif args.dataset_name is not None:
+        dataset_id = get_dataset_id(args)
+        if dataset_id is None:
+            print 'Could not find dataset named {}'.format(args.dataset_name)
+            sys.exit(3)
+    else:
+        dataset_id = initialize_test(kind, args)
+
+    path = os.path.abspath('../build/src/entity-generator/entity-generator')
+    if not os.path.exists(path):
+        print '{} does not exist'.format(path)
+        print 'Please build entity-generator as documented in the README file'
+        sys.exit(1)
+
+    cmd_args = [path, '--test-pattern', '--dataset-id={}'.format(dataset_id),
+                '--entity-count={}'.format(entity_count), '--kind={}'.format(kind)]
+    if args.host:
+        cmd_args.append('--host={}'.format(args.host))
+    if args.api_key:
+        cmd_args.append('--api-key={}'.format(args.api_key))
+    subprocess.call(cmd_args)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,4 @@
+https://github.com/ConduceInc/conduce-python-api/archive/v2.1.1.zip#egg=conduce
+python-dateutil==2.6.1
+pytz==2017.2
+pint==0.8.1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,2 @@
+virtualenv ./venv
+./venv/bin/pip install -r requirements.txt --upgrade

--- a/src/entity-generator/entity-generator.cpp
+++ b/src/entity-generator/entity-generator.cpp
@@ -198,9 +198,6 @@ void parseCommandLine(int argc, char *argv[]) {
       "Number of entities to generate topologies for")(
       "days", po::value<int>(&options.daysToRun)->default_value(1),
       "Days of topologies to send to pool server")(
-      "initialize-topology",
-      po::value<bool>(&options.initialize)->default_value(true),
-      "Add topologies to sluice.  Disable to only send topology updates.")(
       "center-start",
       po::value<bool>(&options.centerStart)->default_value(false),
       "Originate all nodes at the center of the United States.")(

--- a/src/entity-generator/entity-generator.cpp
+++ b/src/entity-generator/entity-generator.cpp
@@ -23,7 +23,7 @@ const std::array<double, 3> CENTER_OF_US = {{-98.5795, 39.8282, 0.}};
 
 struct CommandLineOptions {
   bool initialize = true;
-  int timeInterval = 15;
+  int timeInterval = 1;
   int entityCount = 100;
   bool centerStart = false;
   double stepSize = 0.1;
@@ -208,7 +208,7 @@ void parseCommandLine(int argc, char *argv[]) {
       "interval")(
       "step-size", po::value<double>(&options.stepSize)->default_value(0.1),
       "Distance to move nodes every time interval (decimal degrees)")(
-      "time-interval", po::value<int>(&options.timeInterval)->default_value(15),
+      "time-interval", po::value<int>(&options.timeInterval)->default_value(1),
       "Seconds between topology updates")(
       "endtime-offset",
       po::value<uint64_t>(&options.endtimeOffset)->default_value(0),

--- a/src/entity-generator/entity-generator.cpp
+++ b/src/entity-generator/entity-generator.cpp
@@ -181,9 +181,9 @@ const std::string updateEntities(random_generator &walk) {
 }
 
 void parseCommandLine(int argc, char *argv[]) {
-  po::options_description desc("topology-generator is a utility for sending "
-                               "network fluoroscope data (topologies) to "
-                               "sluice.\n\nConfiguration options");
+  po::options_description desc(
+      "entity-generator is a utility for sending data to Conduce."
+      "\n\nConfiguration options");
   desc.add_options()("help", "Print the list of command line options")(
       "kind", po::value<std::string>(&options.kind)->default_value("default"),
       "Data kind to assign to entities")(

--- a/src/entity-generator/entity-generator.cpp
+++ b/src/entity-generator/entity-generator.cpp
@@ -20,8 +20,6 @@
 namespace po = boost::program_options;
 
 const std::array<double, 3> CENTER_OF_US = {{-98.5795, 39.8282, 0.}};
-// const long long JAN_01_1996_GMT = 820454400000;
-const long long ONE_WEEK = 1000 * 60 * 60 * 24 * 7;
 
 struct CommandLineOptions {
   bool initialize = true;
@@ -33,6 +31,7 @@ struct CommandLineOptions {
   bool live = false;
   bool ungoverned = false;
   int daysToRun = 1;
+  uint64_t startTime = 0;
   uint64_t endtimeOffset = 0;
   std::string hostname;
   std::string dataset;
@@ -130,8 +129,7 @@ void initializeEntities() {
     if (options.live) {
       newEntity.timestamp = NowGMT();
     } else {
-      // newEntity.timestamp = JAN_01_1996_GMT;
-      newEntity.timestamp = NowGMT() - ONE_WEEK;
+      newEntity.timestamp = options.startTime;
     }
     newEntity.kind = options.kind;
     entityList.push_back(newEntity);
@@ -218,6 +216,8 @@ void parseCommandLine(int argc, char *argv[]) {
       "endtime-offset",
       po::value<uint64_t>(&options.endtimeOffset)->default_value(0),
       "Duration after which entity expires (ms)")(
+      "start-time", po::value<uint64_t>(&options.startTime)->default_value(0),
+      "The timestamp at which the first entity sample should occur (ms)")(
       "ungoverned", po::value<bool>(&options.ungoverned)->default_value(false),
       "Generate updates as quickly as possible")(
       "insecure", po::bool_switch(&options.insecure)->default_value(false),

--- a/src/entity-generator/entity-generator.cpp
+++ b/src/entity-generator/entity-generator.cpp
@@ -33,6 +33,7 @@ struct CommandLineOptions {
   bool live = false;
   bool ungoverned = false;
   int daysToRun = 1;
+  uint64_t endtimeOffset = 0;
   std::string hostname;
   std::string dataset;
   std::string apiKey;
@@ -158,10 +159,9 @@ const std::string updateEntities(random_generator &walk) {
                         jsonDoc.GetAllocator());
     newEntity.AddMember("timestamp_ms", rapidjson::Value(entity->timestamp),
                         jsonDoc.GetAllocator());
-    newEntity.AddMember(
-        "endtime_ms",
-        rapidjson::Value(entity->timestamp + options.timeInterval * 1000),
-        jsonDoc.GetAllocator());
+    newEntity.AddMember("endtime_ms", rapidjson::Value(entity->timestamp +
+                                                       options.endtimeOffset),
+                        jsonDoc.GetAllocator());
     newEntity.AddMember(
         "kind", rapidjson::Value(entity->kind.c_str(), entity->kind.size()),
         jsonDoc.GetAllocator());
@@ -215,6 +215,9 @@ void parseCommandLine(int argc, char *argv[]) {
       "Distance to move nodes every time interval (decimal degrees)")(
       "time-interval", po::value<int>(&options.timeInterval)->default_value(15),
       "Seconds between topology updates")(
+      "endtime-offset",
+      po::value<uint64_t>(&options.endtimeOffset)->default_value(0),
+      "Duration after which entity expires (ms)")(
       "ungoverned", po::value<bool>(&options.ungoverned)->default_value(false),
       "Generate updates as quickly as possible")(
       "insecure", po::bool_switch(&options.insecure)->default_value(false),


### PR DESCRIPTION
The change adds a test pattern generate to the options for entity generator.  Enabling this option will cause the entities to move in a 4-step cyclic pattern.

Python scripts have been added to make it very simple to generate a live test pattern and visualize it.

Additionally there is some cleanup in the earlier commits.  Most notably the default state is now to generate samples (start time == end time).