### PR TITLE
timing is everything

### DIFF
--- a/scripts/cleanup-test-patterns
+++ b/scripts/cleanup-test-patterns
@@ -5,7 +5,7 @@ echo -n "This will delete all resource with "generated-test-pattern" in the name
 read answer
 
 if [ "${answer}" == "Yes" ] ; then
-    ./venv/bin/conduce-api remove --regex=generated-test-pattern --all 
+    ./venv/bin/conduce-api remove --regex=generated-test-pattern --all $@
 else
    echo "Operation aborted"
 fi

--- a/src/entity-generator/entity-generator.cpp
+++ b/src/entity-generator/entity-generator.cpp
@@ -71,7 +71,7 @@ const double getStartDate() {
   return (date - epoch).total_milliseconds();
 }
 
-const long long NowGMT() {
+const long long nowUTC() {
   static boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
   boost::posix_time::ptime now =
       boost::posix_time::microsec_clock::universal_time();
@@ -166,7 +166,7 @@ void initializeEntities() {
     }
     newEntity.initialLocation = newEntity.location;
     if (options.live) {
-      newEntity.timestamp = NowGMT();
+      newEntity.timestamp = nowUTC();
     } else {
       newEntity.timestamp = options.startTime;
     }
@@ -186,7 +186,7 @@ const std::string updateEntities(random_generator &walk) {
        entity != entityList.end(); ++entity) {
     updateLocation(entity, walk);
     if (options.live) {
-      entity->timestamp = NowGMT();
+      entity->timestamp = nowUTC();
     } else {
       entity->timestamp += options.timeInterval * 1000;
     }
@@ -450,6 +450,7 @@ int main(int argc, char *argv[]) {
 
   const int UPDATE_COUNT = 3600 * 24 * options.daysToRun / options.timeInterval;
   for (int count = 0; count < UPDATE_COUNT; ++count) {
+    int startTime = nowUTC();
     s = std::string();
     headers.clear();
     const std::string entitiesStr = updateEntities(walk);
@@ -497,9 +498,13 @@ int main(int argc, char *argv[]) {
     waitForCompletion(headers["Location"], curl);
 
     if (!options.ungoverned) {
-      std::cout << getTimeString() << ": Sleeping for " << options.timeInterval
-                << " seconds" << std::endl;
-      sleep(options.timeInterval);
+      int workTime = nowUTC() - startTime;
+      int sleepTime = (options.timeInterval * 1000) - workTime;
+      if (sleepTime > 0) {
+        std::cout << getTimeString() << ": Sleeping for " << sleepTime
+                  << " milliseconds" << std::endl;
+        usleep(sleepTime * 1000);
+      }
     }
   }
 

--- a/src/entity-generator/entity-generator.cpp
+++ b/src/entity-generator/entity-generator.cpp
@@ -449,8 +449,9 @@ int main(int argc, char *argv[]) {
   random_generator walk(alg_walk, walk_range);
 
   const int UPDATE_COUNT = 3600 * 24 * options.daysToRun / options.timeInterval;
+  const int START_TIME = nowUTC();
+  int updateTime = START_TIME;
   for (int count = 0; count < UPDATE_COUNT; ++count) {
-    int startTime = nowUTC();
     s = std::string();
     headers.clear();
     const std::string entitiesStr = updateEntities(walk);
@@ -498,12 +499,16 @@ int main(int argc, char *argv[]) {
     waitForCompletion(headers["Location"], curl);
 
     if (!options.ungoverned) {
-      int workTime = nowUTC() - startTime;
-      int sleepTime = (options.timeInterval * 1000) - workTime;
+      updateTime += options.timeInterval * 1000;
+      int sleepTime = updateTime - nowUTC();
+      ;
       if (sleepTime > 0) {
         std::cout << getTimeString() << ": Sleeping for " << sleepTime
                   << " milliseconds" << std::endl;
         usleep(sleepTime * 1000);
+      } else {
+        std::cout << getTimeString() << ": Behind real-time by " << sleepTime
+                  << " milliseconds" << std::endl;
       }
     }
   }


### PR DESCRIPTION
Update timing logic to take processing time into account before going to sleep.  This help ensure the user specified interval is obeyed.  However, this does not correct for processing time that is greater than the timing interval.  IE if the timing interval is 1 second and the processing takes 2 seconds the data stream will not catch up.

Additionally, update the cleanup script to pass command line arguments through to conduce-api CLI.