### PR TITLE
Enable use of Conduce config

### DIFF
--- a/scripts/generate_test_pattern.py
+++ b/scripts/generate_test_pattern.py
@@ -54,6 +54,7 @@ def main():
 
     default_host = None
     default_user = None
+    default_api_key = None
 
     cfg = conduce.config.get_full_config()
     if cfg:
@@ -85,6 +86,10 @@ def main():
             api_key = conduce.config.get_api_key(args.user, args.host)
             if api_key:
                 args.api_key = api_key
+
+    if args.host is None or args.api_key is None:
+        print "Please specify a target host, and a user or API key"
+        sys.exit(2)
 
     kind = 'generated-test-dot'
 


### PR DESCRIPTION
Fetch API key from Conduce config.  Don't require API key to be specified on command line.

This is a little more code than I hoped but this change enables a user to type `./generate-test-pattern` and as long as they have a `.conduceconfig` with a default host and user specified and a corresponding API key the correct arguments will be passed to entity-generator.

It also works if the user specifies a host and user with a stored API key.  This is useful for deploy builds where a user can add an API key with `conduce-api config set api-key --new`.